### PR TITLE
Add Junit dependencies to pom.xml for unit testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,17 @@
+<dependencies>
+    <!-- JUnit 4 dependency -->
+    <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.13.2</version>
+        <scope>test</scope>
+    </dependency>
+
+    <!-- Mockito dependency for mocking objects -->
+    <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>4.0.0</version>
+        <scope>test</scope>
+    </dependency>
+</dependencies>


### PR DESCRIPTION
Added Junit dependencies to the pom.xml file to enable unit testing for the project. 
This will allow better test coverage and improved code reliability by facilitating the creation and execution of test cases for various classes and methods.